### PR TITLE
DOT-1348: menu on mobile

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -68,16 +68,11 @@
   .headerLink {
     list-style: none;
 
-    min-width: 90px;
+    width: 90px;
     height: 56px;
 
-    @media(max-width: 991.98px) {
-      height: 100%;
-      min-height: 62px;
-    }
-
     @media screen and (max-width: 375px) {
-      min-width: 64px;
+      width: 64px;
       padding-bottom: 4px;
     }
 
@@ -164,16 +159,6 @@
       position: relative;
       top: -23px;
       text-decoration: underline;
-
-      @media (max-width: 991.98px) {
-        border-top: 0 !important;
-        border-bottom: 7px solid #000000;
-        top: 0 !important;
-        padding-top: 0 !important;
-        margin-top: 0 !important;
-        height: 47px;
-      }
-
       }
     }
   }
@@ -203,6 +188,25 @@
         display: none;
       }
     }
+  }
+}
+
+@media screen and (min-width: 376px) and (max-width: 991.98px) {
+  .custom-header-links {
+    .active, .talk, li:hover {
+      border-bottom: 4px solid black;
+      padding-bottom: 0px;
+    }
+  }
+
+  .headerLink {
+    width: 90px;
+    margin: auto;
+    margin-right: auto !important;
+    padding-bottom: 4px;
+    -webkit-box-align: center!important;
+    -ms-flex-align: center!important;
+    align-items: center!important;
   }
 }
 

--- a/common/common.scss
+++ b/common/common.scss
@@ -67,17 +67,26 @@
   margin-left:0;
   .headerLink {
     list-style: none;
-    
+
     min-width: 90px;
-    height: 60px;
+    height: 56px;
 
     @media(max-width: 991.98px) {
       height: 100%;
       min-height: 62px;
     }
 
+    @media screen and (max-width: 375px) {
+      min-width: 64px;
+      padding-bottom: 4px;
+    }
+
     &:not(:last-child) {
       margin-right: 15px;
+
+      @media screen and (max-width: 375px) {
+        margin-right: 0px;
+      }
     }
 
     a {
@@ -97,6 +106,7 @@
       @media screen and (max-width: 991.98px) {
         margin-top: unset !important;
         padding-top: unset !important;
+        border-top: unset !important;
         top: unset !important;
       }
     }
@@ -130,7 +140,7 @@
 
   .restarters-events-icon {
     background-image:
-        url('data:image/svg+xml;utf8,<svg width="30" height="25" viewBox="0 0 30 25" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;"><g id="Path_72" transform="matrix(1,0,0,1,-1,-2)"><path d="M24.75,4.5L23.5,4.5L23.5,3.25C23.5,2.564 22.936,2 22.25,2C21.564,2 21,2.564 21,3.25L21,4.5L8.5,4.5L8.5,3.25C8.5,2.564 7.936,2 7.25,2C6.564,2 6,2.564 6,3.25L6,4.5L4.75,4.5C2.693,4.5 1,6.193 1,8.25L1,23.25C1,25.307 2.693,27 4.75,27L24.75,27C26.807,27 28.5,25.307 28.5,23.25L28.5,8.25C28.5,6.193 26.807,4.5 24.75,4.5ZM3.5,8.25C3.5,7.564 4.064,7 4.75,7L24.75,7C25.436,7 26,7.564 26,8.25L26,9.5L3.5,9.5L3.5,8.25ZM26,23.25C26,23.936 25.436,24.5 24.75,24.5L4.75,24.5C4.064,24.5 3.5,23.936 3.5,23.25L3.5,12L26,12L26,23.25Z" style="fill:rgb(14,19,23);"></path></g><g transform="matrix(1,0,0,1,-3.21859,1.0671)"><path d="M16.969,11.433L18.149,13.546L20.427,14.072L18.878,15.903L19.106,18.341L16.969,17.36L14.831,18.341L15.059,15.903L13.51,14.072L15.789,13.546L16.969,11.433Z" style="fill:none;stroke:black;stroke-width:1px;"></path></g></svg>');
+      url("data:image/svg+xml;charset=utf8,%3Csvg width='100%25' height='100%25' viewBox='0 0 28 25' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' xml:space='preserve' xmlns:serif='http://www.serif.com/' style='fill-rule:evenodd;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;'%3E%3Cg id='Path_72' transform='matrix(1,0,0,1,-1,-2)'%3E%3Cpath d='M24.75,4.5L23.5,4.5L23.5,3.25C23.5,2.564 22.936,2 22.25,2C21.564,2 21,2.564 21,3.25L21,4.5L8.5,4.5L8.5,3.25C8.5,2.564 7.936,2 7.25,2C6.564,2 6,2.564 6,3.25L6,4.5L4.75,4.5C2.693,4.5 1,6.193 1,8.25L1,23.25C1,25.307 2.693,27 4.75,27L24.75,27C26.807,27 28.5,25.307 28.5,23.25L28.5,8.25C28.5,6.193 26.807,4.5 24.75,4.5ZM3.5,8.25C3.5,7.564 4.064,7 4.75,7L24.75,7C25.436,7 26,7.564 26,8.25L26,9.5L3.5,9.5L3.5,8.25ZM26,23.25C26,23.936 25.436,24.5 24.75,24.5L4.75,24.5C4.064,24.5 3.5,23.936 3.5,23.25L3.5,12L26,12L26,23.25Z' style='fill:rgb(14,19,23);'/%3E%3C/g%3E%3Cg transform='matrix(1,0,0,1,-3.21859,1.0671)'%3E%3Cpath d='M16.969,11.433L18.149,13.546L20.427,14.072L18.878,15.903L19.106,18.341L16.969,17.36L14.831,18.341L15.059,15.903L13.51,14.072L15.789,13.546L16.969,11.433Z' style='fill:none;stroke:black;stroke-width:1px;'/%3E%3C/g%3E%3C/svg%3E");
   }
 
   .restarters-groups-icon {
@@ -196,6 +206,23 @@
   }
 }
 
+@media screen and (max-width: 375px) {
+  .custom-header-links {
+    .active, .talk, li:hover {
+      border-bottom: 4px solid black;
+      padding-bottom: 0px;
+    }
+  }
+
+  .headerLink {
+    min-width: 64px;
+    padding-bottom: 4px;
+
+    &:not(:last-child) {
+      margin-right: 0px;
+    }
+  }
+}
 
 .desktop-view .vmo,
 .mobile-view .vdo {


### PR DESCRIPTION
Make the menu on Talk match the menu on Restarters for mobile and tablet screen sizes.

There's still a jump at desktop screen sizes, but this proved quite fiddly so I'm leaving any desktop changes to a later story.  

James has tested.